### PR TITLE
feature/certificate `remove: h1`

### DIFF
--- a/web-app/pages/certificate/[tokenId].tsx
+++ b/web-app/pages/certificate/[tokenId].tsx
@@ -10,7 +10,6 @@ import type { NextPage } from 'next';
 import { useRouter } from 'next/router';
 import Layout from '../../components/Layout';
 import { baseUrl } from '../../helpers/strings';
-import styles from '../../styles/Account.module.scss';
 
 function buildTwitterUrl(pngUrl: string) {
   // https://stevenwestmoreland.com/2018/07/creating-social-sharing-links-without-javascript.html
@@ -48,7 +47,6 @@ const Certificate: NextPage = () => {
 
   return (
     <Layout>
-      <h1 className={styles.title}>{tokenId}</h1>
       <a href={`/api/cert/${tokenId}.svg`}>
         <img src={pngUrl} alt={`certificate ${tokenId}`} />
       </a>


### PR DESCRIPTION
@ryancwalsh, 

- According to this [comment](https://github.com/NEAR-Edu/near-certification-tools/pull/7#issuecomment-1040390095) I remove the `h1`

![image](https://user-images.githubusercontent.com/70068338/154257954-4ceaea9a-69c7-4e46-9fb9-780c105084ed.png)

