### PR TITLE
feature/account-header-padding `fix: header padding`

### DIFF
--- a/web-app/pages/account/[account].tsx
+++ b/web-app/pages/account/[account].tsx
@@ -44,7 +44,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
 const Account: NextPage<AccountPageProps> = ({ accountId, certificates }: AccountPageProps) => {
   return (
     <Layout>
-      <h1 className={styles.title}>{accountId}&rsquo;s Certificates</h1>
+      <h1 className="text-center text-3xl sm:text-4xl">{accountId}&rsquo;s Certificates</h1>
 
       <div className={styles.grid}>
         {certificates.length > 0 ? certificates.map((tokenId: string) => <Tile tokenId={tokenId} key={tokenId} />) : <span>No certificates yet!</span>}

--- a/web-app/styles/Account.module.scss
+++ b/web-app/styles/Account.module.scss
@@ -1,10 +1,3 @@
-.title {
-  margin: 0;
-  margin-bottom: 3rem;
-  line-height: 1.15;
-  font-size: 4rem;
-}
-
 .grid {
   display: flex;
   align-items: center;

--- a/web-app/styles/Account.module.scss
+++ b/web-app/styles/Account.module.scss
@@ -4,7 +4,6 @@
   justify-content: center;
   flex-wrap: wrap;
   max-width: 800px;
-  margin-top: 3rem;
 }
 
 .card {

--- a/web-app/styles/Layout.module.scss
+++ b/web-app/styles/Layout.module.scss
@@ -8,7 +8,7 @@
 }
 
 .main {
-  padding: 5rem 0;
+  padding: 2rem 0;
   flex: 1;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
@ryancwalsh according to https://github.com/NEAR-Edu/near-certification-tools/pull/7#issuecomment-1041509218 `#3` I did below changes

1. Remove `scss` style for h1 and add `tailwind` styles.

> I hope removing `scss` style for the h1 is ok. I did this because do responsive is easier with tailwind but if it is not ok I can also search for internet and find how to do it with `scss`

BEFORE

![17 02 22_account_before](https://user-images.githubusercontent.com/70068338/154496290-c03b6add-7515-485d-adcc-3b7fb9e3e5e9.png)

AFTER

![17 02 22_account_after](https://user-images.githubusercontent.com/70068338/154496338-f9ccdaa5-01fe-409b-83aa-809e1b417013.png)


