### PR TITLE
feature/certificate-size `fix: certificate size`

### DIFF
--- a/web-app/pages/certificate/[tokenId].tsx
+++ b/web-app/pages/certificate/[tokenId].tsx
@@ -47,7 +47,7 @@ const Certificate: NextPage = () => {
 
   return (
     <Layout>
-      <a href={`/api/cert/${tokenId}.svg`}>
+      <a href={`/api/cert/${tokenId}.svg`} className="md:max-w-xl lg:max-w-2xl">
         <img src={pngUrl} alt={`certificate ${tokenId}`} />
       </a>
       <div className="text-sm mt-2 ml-2">


### PR DESCRIPTION
@ryancwalsh according to https://github.com/NEAR-Edu/near-certification-tools/pull/7#issuecomment-1042535849 I made below changes

- resize the certificate for small devices and make resposive

> I tried `max-height: 500px;` but I couldn't get result maybe I am doing sth wrong but then I implemented `tailwind` styleing and It worked. I hope this is what you want to see.

BEFORE

![17 02 22_certificate-site_before](https://user-images.githubusercontent.com/70068338/154513902-b186132c-b11b-49c9-9e3b-61fb782361f0.png)


AFTER

![17 02 22_certificate-site_after](https://user-images.githubusercontent.com/70068338/154513944-6609938f-962f-491c-b7d7-3d51fdba0757.png)

