### PR TITLE
fix: size of cert (see #23)

### DIFF
--- a/web-app/components/Footer.tsx
+++ b/web-app/components/Footer.tsx
@@ -5,7 +5,7 @@ export default function Footer() {
     <footer className="bg-gray-100 shadow-[1px_1px_10px_1px_rgba(0,0,0,0.2)]">
       <div className="mx-auto px-4 flex items-center justify-center">
         <a className="pt-5 mr-8 pb-5" href="https://NEAR.University" target="_blank" rel="noopener noreferrer">
-          <img className="min-w-full" alt="NEAR University logo" width="200px" src="/near_university_logo.svg" />{' '}
+          <img className="min-w-full" alt="NEAR University logo" width="200px" src="/near_university_logo.svg" />
         </a>
         <FooterSocials />
         <a href="https://jobs.near.university/" target="_blank" rel="noopener noreferrer" className="text-base font-medium text-gray-500 hover:text-gray-900 py-5">

--- a/web-app/pages/certificate/[tokenId].tsx
+++ b/web-app/pages/certificate/[tokenId].tsx
@@ -75,7 +75,7 @@ const CertificatePage: NextPage<CertificatePageProps> = ({ tokenId }: Certificat
     <>
       <OpenGraphMetaData pngUrl={pngUrl} certificateUrl={certificateUrl} />
       <Layout>
-        <a href={`/api/cert/${tokenId}.svg`} className="md:max-w-lg">
+        <a href={`/api/cert/${tokenId}.svg`} className="md:max-w-lg lg:max-w-2xl">
           <img src={pngUrl} alt={`certificate ${tokenId}`} />
         </a>
         <div className="text-sm mt-2 ml-2">

--- a/web-app/pages/certificate/[tokenId].tsx
+++ b/web-app/pages/certificate/[tokenId].tsx
@@ -75,7 +75,7 @@ const CertificatePage: NextPage<CertificatePageProps> = ({ tokenId }: Certificat
     <>
       <OpenGraphMetaData pngUrl={pngUrl} certificateUrl={certificateUrl} />
       <Layout>
-        <a href={`/api/cert/${tokenId}.svg`}>
+        <a href={`/api/cert/${tokenId}.svg`} className="md:max-w-lg">
           <img src={pngUrl} alt={`certificate ${tokenId}`} />
         </a>
         <div className="text-sm mt-2 ml-2">


### PR DESCRIPTION
@ryancwalsh  According to https://github.com/NEAR-Edu/near-certification-tools/issues/23 I figured out that the reason is this [branch](https://github.com/NEAR-Edu/near-certification-tools/pull/20/files#diff-dc14b33a17916722b867cf415a79a02e0be99d1d8d70709e87a853735bfa4916L50). 

I don't know why but somehow this line

 ![image](https://user-images.githubusercontent.com/70068338/155315559-2384056f-0f44-4e77-a269-d649e6d46676.png) 

replaced with this line 

![image](https://user-images.githubusercontent.com/70068338/155315727-dde51cf7-4d84-46b7-89cd-f8e0d77156bb.png)
 (original version that before I work on it)

Also fixed weird part `{' '}` from https://github.com/NEAR-Edu/near-certification-tools/pull/9#discussion_r812287955

AFTER

![after_certificate-size-redo](https://user-images.githubusercontent.com/70068338/155327540-2e33e211-a27b-416f-93ee-8e4edab6e842.png)

