### PR TITLE
Feature/redirect to 404page

### DIFF
--- a/web-app/pages/api/cert/[imageFileName].ts
+++ b/web-app/pages/api/cert/[imageFileName].ts
@@ -84,7 +84,7 @@ async function getExpiration(accountName: string): Promise<string> {
 }
 
 // eslint-disable-next-line max-lines-per-function
-async function fetchCertificateDetails(tokenId: string) {
+export async function fetchCertificateDetails(tokenId: string) {
   const account = await getNearAccountWithoutAccountIdOrKeyStoreForBackend();
   const contract = getNftContract(account);
   const response = await (contract as NFT).nft_token({ token_id: tokenId });

--- a/web-app/pages/certificate/[tokenId].tsx
+++ b/web-app/pages/certificate/[tokenId].tsx
@@ -10,6 +10,7 @@ import type { GetServerSideProps, NextPage } from 'next';
 import Head from 'next/head';
 import Layout from '../../components/Layout';
 import { baseUrl } from '../../helpers/strings';
+import { fetchCertificateDetails } from '../api/cert/[imageFileName]';
 
 const title = 'I got certified on the NEAR blockchain!';
 const description = 'View NEAR University certificates of any .near account';
@@ -31,10 +32,15 @@ function buildLinkedInUrl(certificateUrl: string) {
 }
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
-  // https://nextjs.org/docs/api-reference/data-fetching/get-server-side-props
   const { tokenId } = context.query; // https://nextjs.org/docs/routing/dynamic-routes
-  console.log({ tokenId });
-  // TODO: In getServerSideProps, check for existence of cert of this tokenId, and ensure that it's valid. If does not exist or is invalid, return HTTP_ERROR_CODE_MISSING error.
+  const castingTokenId: string = tokenId as string;
+  const details = await fetchCertificateDetails(castingTokenId);
+
+  if (!details) {
+    return {
+      notFound: true,
+    };
+  }
 
   return {
     props: {

--- a/web-app/pages/certificate/[tokenId].tsx
+++ b/web-app/pages/certificate/[tokenId].tsx
@@ -38,7 +38,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
 
   if (!details) {
     return {
-      notFound: true,
+      notFound: true, // https://nextjs.org/docs/api-reference/data-fetching/get-server-side-props#notfound
     };
   }
 


### PR DESCRIPTION
***Not existing tokenIds will not be rendered on the page, instead, they will be redirected to the 404 page***

![image](https://user-images.githubusercontent.com/45902312/156570542-fe6f065c-e0fc-40c8-b32a-6f135bdaecc8.png)
---
***I invalidate one of the certificates with this command***

![image](https://user-images.githubusercontent.com/45902312/156570625-ee4bd667-bef3-4d1b-8ab7-1f942f0f3ce8.png)
---
***If the certificate is invalid, then it will be redirected to 404 page***

![image](https://user-images.githubusercontent.com/45902312/156570706-83e74bc1-87a1-4b8d-99dd-961190992221.png)
---

We solved this issue https://github.com/NEAR-Edu/near-certification-tools/issues/32 as a team. Thank you @ozanisgor @rashaabdulrazzak @hiba-machfej 


