### PR TITLE
fix: rename 404 text

### DIFF
--- a/web-app/pages/404.tsx
+++ b/web-app/pages/404.tsx
@@ -3,7 +3,7 @@ export default function ErrorPage404() {
     <div className="bg-white px-4 py-16 sm:px-6 sm:py-24 sm:h-screen md:grid md:place-content-center lg:px-8">
       <div className="max-w-max mx-auto">
         <main className="sm:flex">
-          <p className="text-4xl font-extrabold text-purple-600 sm:text-5xl">404</p>
+          <p className="text-4xl font-extrabold text-purple-600 sm:text-5xl">ERROR</p>
           <div className="sm:ml-6">
             <div className="sm:border-l sm:border-gray-200 sm:pl-6">
               <h1 className="text-4xl font-extrabold text-gray-900 tracking-tight sm:text-5xl">Page not found</h1>

--- a/web-app/pages/404.tsx
+++ b/web-app/pages/404.tsx
@@ -3,9 +3,8 @@ export default function ErrorPage404() {
     <div className="bg-white px-4 py-16 sm:px-6 sm:py-24 sm:h-screen md:grid md:place-content-center lg:px-8">
       <div className="max-w-max mx-auto">
         <main className="sm:flex">
-          <p className="text-4xl font-extrabold text-purple-600 sm:text-5xl">ERROR</p>
           <div className="sm:ml-6">
-            <div className="sm:border-l sm:border-gray-200 sm:pl-6">
+            <div className="sm:pl-6">
               <h1 className="text-4xl font-extrabold text-gray-900 tracking-tight sm:text-5xl">Page not found</h1>
               <p className="mt-1 text-base text-gray-500">There is no page at this address.</p>
             </div>


### PR DESCRIPTION
https://github.com/NEAR-Edu/near-certification-tools/pull/42#issuecomment-1061871395
I used capital letters for the replacement of "404" text

Here how it looks
![image](https://user-images.githubusercontent.com/45902312/157271026-311f4955-9a49-47ba-b1dd-e4a6142a489c.png)

And this is the lower case "Error" message
![image](https://user-images.githubusercontent.com/45902312/157271344-38a73605-b473-4db6-9edd-b059bb6eeede.png)


I think the first one looks better but I can change according to your liking

